### PR TITLE
Bim 272 converter packed metadata from gltfpack and output metadata file

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -207,21 +207,22 @@ static bool printMergeMetadata(const char* path, const std::vector<Mesh>& meshes
 		append(json, mesh.parent_node_name);
 		append(json, "\"");
 
-		char* last_merged_mesh_name = (char*)mesh_unique_name.c_str();
+		char* last_merged_mesh_name = (char*)mesh.parent_node_name;
 		for (size_t j = 0; j < mesh.merged_meshes_parent_node_info.size(); ++j) {
 			const char* merged_mesh_parent_node_name = mesh.merged_meshes_parent_node_info[j].first;
 
 			// skip meshes that have duplicated names one after the other, as the index of the first one
 			// is enough to retrieve the expected name for sure
-			if (last_merged_mesh_name == nullptr || strcmp(merged_mesh_parent_node_name, last_merged_mesh_name) != 0) {
+			if (strcmp(merged_mesh_parent_node_name, last_merged_mesh_name) != 0) {
 				comma(json);
 				append(json, "\"");
 				append(json, std::to_string(mesh.merged_meshes_parent_node_info[j].second).c_str());
 				append(json, "\":\"");
 				append(json, merged_mesh_parent_node_name);
 				append(json, "\"");
+
+				last_merged_mesh_name = (char*)merged_mesh_parent_node_name;
 			}
-			last_merged_mesh_name = (char*)merged_mesh_parent_node_name;
 		}
 
 		append(json, "}");

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -555,6 +555,14 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	{
 		const Mesh& mesh = meshes[i];
 
+		//
+		const char* mesh_name = nullptr;
+		if (settings.keep_mesh_parent_nodes) {
+			// compute a unique name for the mesh, since a parent node with a given name can have several meshes
+			std::string identifier = std::string(mesh.parent_node_name) + "_" + std::to_string(mesh.index_in_parent_node);
+			mesh_name = identifier.c_str();
+		}
+
 		comma(json_meshes);
 		append(json_meshes, "{\"primitives\":[");
 
@@ -687,7 +695,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 				{
 					ni.mesh_nodes.push_back(node_offset);
 
-					writeMeshNode(json_nodes, mesh_offset, mesh.nodes[j], mesh.skin, data, settings.quantize && !settings.pos_float ? &qp : NULL);
+					writeMeshNode(json_nodes, mesh_offset, mesh_name, mesh.nodes[j], mesh.skin, data, settings.quantize && !settings.pos_float ? &qp : NULL);
 
 					node_offset++;
 				}
@@ -714,7 +722,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 			comma(json_roots[mesh.scene]);
 			append(json_roots[mesh.scene], node_offset);
 
-			writeMeshNode(json_nodes, mesh_offset, NULL, mesh.skin, data, settings.quantize && !settings.pos_float ? &qp : NULL);
+			writeMeshNode(json_nodes, mesh_offset, mesh_name, NULL, mesh.skin, data, settings.quantize && !settings.pos_float ? &qp : NULL);
 
 			node_offset++;
 		}

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -308,7 +308,7 @@ static void detachMesh(Mesh& mesh, cgltf_data* data, const std::vector<NodeInfo>
 	}
 	else if (canTransformMesh(mesh))
 	{
-		mergeMeshInstances(mesh);
+		mergeMeshInstances(mesh, settings);
 
 		assert(mesh.nodes.empty());
 		mesh.scene = scene;

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -1523,7 +1523,7 @@ int main(int argc, char** argv)
 		{
 			report = argv[++i];
 		}
-		else if (strcmp(arg, "-mmd") == 0 && i + 1 < argc && !merge_metadata)
+		else if (strcmp(arg, "-mmi") == 0 && i + 1 < argc && !merge_metadata)
 		{
 			merge_metadata = argv[++i];
 		}
@@ -1656,7 +1656,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t-noq: disable quantization; produces much larger glTF files with no extensions\n");
 			fprintf(stderr, "\t-v: verbose output (print version when used without other options)\n");
 			fprintf(stderr, "\t-r file: output a JSON report to file\n");
-			fprintf(stderr, "\t-mmd file: output a JSON file containing the merge metadata information\n");
+			fprintf(stderr, "\t-mmi file: output a JSON file containing the merge metadata information\n");
 			fprintf(stderr, "\t-h: display this help and exit\n");
 		}
 		else

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -559,7 +559,8 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		append(json_meshes, "{\"primitives\":[");
 
 		size_t pi = i;
-		for (; pi < meshes.size(); ++pi)
+		size_t meshes_size = settings.keep_mesh_parent_nodes ? i+1 : meshes.size();
+		for (; pi < meshes_size; ++pi)
 		{
 			const Mesh& prim = meshes[pi];
 
@@ -721,9 +722,11 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		mesh_offset++;
 		ext_instancing = ext_instancing || !mesh.instances.empty();
 
-		// skip all meshes that we've written in this iteration
-		assert(pi > i);
-		i = pi - 1;
+		if (!settings.keep_mesh_parent_nodes) {
+			// skip all meshes that we've written in this iteration
+			assert(pi > i);
+			i = pi - 1;
+		}
 	}
 
 	remapNodes(data, nodes, node_offset);
@@ -1314,6 +1317,10 @@ int main(int argc, char** argv)
 		{
 			settings.keep_attributes = true;
 		}
+		else if (strcmp(arg, "-kmpn") == 0)
+		{
+			settings.keep_mesh_parent_nodes = true;
+		}
 		else if (strcmp(arg, "-mm") == 0)
 		{
 			settings.mesh_merge = true;
@@ -1543,6 +1550,7 @@ int main(int argc, char** argv)
 			fprintf(stderr, "\t-vtf: use floating point attributes for texture coordinates\n");
 			fprintf(stderr, "\t-vnf: use floating point attributes for normals\n");
 			fprintf(stderr, "\t-kv: keep source vertex attributes even if they aren't used\n");
+			fprintf(stderr, "\t-kmpn: keep mesh parent nodes that carry out names\n");
 			fprintf(stderr, "\nAnimations:\n");
 			fprintf(stderr, "\t-at N: use N-bit quantization for translations (default: 16; N should be between 1 and 24)\n");
 			fprintf(stderr, "\t-ar N: use N-bit quantization for rotations (default: 12; N should be between 4 and 16)\n");

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -75,6 +75,12 @@ static void finalizeBufferViews(std::string& json, std::vector<BufferView>& view
 	}
 }
 
+static void mesh_name_with_parent_node_info(const Mesh& mesh, std::string* mesh_name)
+{
+	 // compute a unique name for the mesh, since a parent node with a given name can have several meshes
+	*mesh_name = std::string(mesh.parent_node_name) + "_" + std::to_string(mesh.index_in_parent_node);
+}
+
 static void printMeshStats(const std::vector<Mesh>& meshes, const char* name)
 {
 	size_t mesh_triangles = 0;
@@ -188,12 +194,12 @@ static bool printMergeMetadata(const char* path, const std::vector<Mesh>& meshes
 
 	for (size_t i = 0; i < meshes.size(); ++i) {
 		const Mesh& mesh = meshes[i];
-		// compute the unique key for the mesh, since a parent node with a given name can have several meshes
-		std::string mesh_unique_name = std::string(mesh.parent_node_name) + "_" + std::to_string(mesh.index_in_parent_node);
+		std::string mesh_unique_name = std::string();
+		mesh_name_with_parent_node_info(mesh, &mesh_unique_name);
 
 		comma(json);
 		append(json, "\"");
-		append(json, std::string(mesh.parent_node_name) + "_" + std::to_string(mesh.index_in_parent_node));
+		append(json, mesh_unique_name);
 		append(json, "\":{");
 
 		// the first mesh is the initial one, in which all others were merged into
@@ -618,12 +624,9 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 	{
 		const Mesh& mesh = meshes[i];
 
-		//
-		const char* mesh_name = nullptr;
+		std::string mesh_name = std::string();
 		if (settings.keep_mesh_parent_nodes) {
-			// compute a unique name for the mesh, since a parent node with a given name can have several meshes
-			std::string identifier = std::string(mesh.parent_node_name) + "_" + std::to_string(mesh.index_in_parent_node);
-			mesh_name = identifier.c_str();
+			mesh_name_with_parent_node_info(mesh, &mesh_name);
 		}
 
 		comma(json_meshes);

--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -189,10 +189,12 @@ static void printImageStats(const std::vector<BufferView>& views, TextureKind ki
 		printf("stats: image %s: %d bytes in %d images\n", name, int(bytes), int(count));
 }
 
-static bool printMergeMetadata(const char* path, const std::vector<Mesh>& meshes) {
+static bool printMergeMetadata(const char* path, const std::vector<Mesh>& meshes)
+{
 	std::string json;
 
-	for (size_t i = 0; i < meshes.size(); ++i) {
+	for (size_t i = 0; i < meshes.size(); ++i)
+	{
 		const Mesh& mesh = meshes[i];
 		std::string mesh_unique_name = std::string();
 		mesh_name_with_parent_node_info(mesh, &mesh_unique_name);
@@ -208,12 +210,14 @@ static bool printMergeMetadata(const char* path, const std::vector<Mesh>& meshes
 		append(json, "\"");
 
 		char* last_merged_mesh_name = (char*)mesh.parent_node_name;
-		for (size_t j = 0; j < mesh.merged_meshes_parent_node_info.size(); ++j) {
+		for (size_t j = 0; j < mesh.merged_meshes_parent_node_info.size(); ++j)
+		{
 			const char* merged_mesh_parent_node_name = mesh.merged_meshes_parent_node_info[j].first;
 
 			// skip meshes that have duplicated names one after the other, as the index of the first one
 			// is enough to retrieve the expected name for sure
-			if (strcmp(merged_mesh_parent_node_name, last_merged_mesh_name) != 0) {
+			if (strcmp(merged_mesh_parent_node_name, last_merged_mesh_name) != 0)
+			{
 				comma(json);
 				append(json, "\"");
 				append(json, std::to_string(mesh.merged_meshes_parent_node_info[j].second).c_str());
@@ -626,7 +630,8 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		const Mesh& mesh = meshes[i];
 
 		std::string mesh_name = std::string();
-		if (settings.keep_mesh_parent_nodes) {
+		if (settings.keep_mesh_parent_nodes)
+		{
 			mesh_name_with_parent_node_info(mesh, &mesh_name);
 		}
 
@@ -797,7 +802,8 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		mesh_offset++;
 		ext_instancing = ext_instancing || !mesh.instances.empty();
 
-		if (!settings.keep_mesh_parent_nodes) {
+		if (!settings.keep_mesh_parent_nodes)
+		{
 			// skip all meshes that we've written in this iteration
 			assert(pi > i);
 			i = pi - 1;

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -385,7 +385,7 @@ void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std:
 size_t writeMeshIndices(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, const Settings& settings);
 size_t writeJointBindMatrices(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const cgltf_skin& skin, const QuantizationPosition& qp, const Settings& settings);
 size_t writeInstances(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const std::vector<Transform>& transforms, const QuantizationPosition& qp, const Settings& settings);
-void writeMeshNode(std::string& json, size_t mesh_offset, const char* name, cgltf_node* node, cgltf_skin* skin, cgltf_data* data, const QuantizationPosition* qp);
+void writeMeshNode(std::string& json, size_t mesh_offset, std::string& name, cgltf_node* node, cgltf_skin* skin, cgltf_data* data, const QuantizationPosition* qp);
 void writeMeshNodeInstanced(std::string& json, size_t mesh_offset, size_t accr_offset);
 void writeSkin(std::string& json, const cgltf_skin& skin, size_t matrix_accr, const std::vector<NodeInfo>& nodes, cgltf_data* data);
 void writeNode(std::string& json, const cgltf_node& node, const std::vector<NodeInfo>& nodes, cgltf_data* data);

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -386,7 +386,7 @@ void writeMeshAttributes(std::string& json, std::vector<BufferView>& views, std:
 size_t writeMeshIndices(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const Mesh& mesh, const Settings& settings);
 size_t writeJointBindMatrices(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const cgltf_skin& skin, const QuantizationPosition& qp, const Settings& settings);
 size_t writeInstances(std::vector<BufferView>& views, std::string& json_accessors, size_t& accr_offset, const std::vector<Transform>& transforms, const QuantizationPosition& qp, const Settings& settings);
-void writeMeshNode(std::string& json, size_t mesh_offset, cgltf_node* node, cgltf_skin* skin, cgltf_data* data, const QuantizationPosition* qp);
+void writeMeshNode(std::string& json, size_t mesh_offset, const char* name, cgltf_node* node, cgltf_skin* skin, cgltf_data* data, const QuantizationPosition* qp);
 void writeMeshNodeInstanced(std::string& json, size_t mesh_offset, size_t accr_offset);
 void writeSkin(std::string& json, const cgltf_skin& skin, size_t matrix_accr, const std::vector<NodeInfo>& nodes, cgltf_data* data);
 void writeNode(std::string& json, const cgltf_node& node, const std::vector<NodeInfo>& nodes, cgltf_data* data);

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -136,6 +136,7 @@ struct Settings
 	bool keep_materials;
 	bool keep_extras;
 	bool keep_attributes;
+	bool keep_mesh_parent_nodes;
 
 	bool mesh_merge;
 	bool mesh_instancing;

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -66,8 +66,7 @@ struct Mesh
 	const char* parent_node_name;
 	size_t index_in_parent_node;
 
-	std::vector<const char*> merged_meshes_parent_node_names;
-	std::vector<unsigned int> merged_meshes_parent_node_start_indices;
+	std::vector<std::pair<const char*, unsigned int> >merged_meshes_parent_node_info;
 };
 
 struct Track
@@ -321,7 +320,7 @@ bool compareMeshTargets(const Mesh& lhs, const Mesh& rhs);
 bool compareMeshVariants(const Mesh& lhs, const Mesh& rhs);
 bool compareMeshNodes(const Mesh& lhs, const Mesh& rhs);
 
-void mergeMeshInstances(Mesh& mesh);
+void mergeMeshInstances(Mesh& mesh, const Settings& settings);
 void mergeMeshes(std::vector<Mesh>& meshes, const Settings& settings);
 void filterEmptyMeshes(std::vector<Mesh>& meshes);
 void filterStreams(Mesh& mesh, const MaterialInfo& mi);

--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -62,6 +62,12 @@ struct Mesh
 	std::vector<const char*> target_names;
 
 	std::vector<cgltf_material_mapping> variants;
+
+	const char* parent_node_name;
+	size_t index_in_parent_node;
+
+	std::vector<const char*> merged_meshes_parent_node_names;
+	std::vector<unsigned int> merged_meshes_parent_node_start_indices;
 };
 
 struct Track

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -257,9 +257,11 @@ static void mergeMeshes(Mesh& target, const Mesh& mesh, const Settings& settings
 
 	size_t index_count = mesh.indices.size();
 
-	for (size_t i = 0; i < index_count; ++i) {
+	for (size_t i = 0; i < index_count; ++i)
+	{
 		target.indices[index_offset + i] = unsigned(vertex_offset + mesh.indices[i]);
-		if (settings.keep_mesh_parent_nodes) {
+		if (settings.keep_mesh_parent_nodes)
+		{
 			target.merged_meshes_parent_node_info.push_back(std::pair<const char*, unsigned int>(mesh.parent_node_name, index_offset));
 		}
 	}

--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -154,10 +154,12 @@ static void createNodesToChildMeshesMap(cgltf_data* data, std::map<cgltf_mesh*, 
 	{
 		cgltf_node& node = data->nodes[ni];
 
-		for (size_t j = 0; j < node.children_count; ++j) {
+		for (size_t j = 0; j < node.children_count; ++j)
+		{
 			cgltf_node* child_node = *(&node.children[j]);
 
-			if (child_node->mesh && node.name) {
+			if (child_node->mesh && node.name)
+			{
 				map.insert(std::pair<cgltf_mesh*, std::pair<const char*, const size_t> >(child_node->mesh, std::make_pair(node.name, j)));
 			}
 		}
@@ -206,7 +208,8 @@ static void parseMeshesGltf(cgltf_data* data, std::vector<Mesh>& meshes, std::ve
 			size_t vertex_count = primitive.attributes_count ? primitive.attributes[0].data->count : 0;
 
 			// save the parent node info to the mesh
-			if (nodes_to_child_meshes_map_it != nodes_to_child_meshes_map.end()) {
+			if (nodes_to_child_meshes_map_it != nodes_to_child_meshes_map.end())
+			{
 				result.parent_node_name = nodes_to_child_meshes_map_it->second.first;
 				result.index_in_parent_node = nodes_to_child_meshes_map_it->second.second;
 			}

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -1180,12 +1180,12 @@ size_t writeInstances(std::vector<BufferView>& views, std::string& json_accessor
 	return result;
 }
 
-void writeMeshNode(std::string& json, size_t mesh_offset, const char* name, cgltf_node* node, cgltf_skin* skin, cgltf_data* data, const QuantizationPosition* qp)
+void writeMeshNode(std::string& json, size_t mesh_offset, std::string& name, cgltf_node* node, cgltf_skin* skin, cgltf_data* data, const QuantizationPosition* qp)
 {
 	comma(json);
 	append(json, "{\"mesh\":");
 	append(json, mesh_offset);
-	if (name) {
+	if (!name.empty()) {
 		append(json, ",\"name\":\"");
 		append(json, name);
 		append(json, "\"");

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -1180,11 +1180,16 @@ size_t writeInstances(std::vector<BufferView>& views, std::string& json_accessor
 	return result;
 }
 
-void writeMeshNode(std::string& json, size_t mesh_offset, cgltf_node* node, cgltf_skin* skin, cgltf_data* data, const QuantizationPosition* qp)
+void writeMeshNode(std::string& json, size_t mesh_offset, const char* name, cgltf_node* node, cgltf_skin* skin, cgltf_data* data, const QuantizationPosition* qp)
 {
 	comma(json);
 	append(json, "{\"mesh\":");
 	append(json, mesh_offset);
+	if (name) {
+		append(json, ",\"name\":\"");
+		append(json, name);
+		append(json, "\"");
+	}
 	if (skin)
 	{
 		append(json, ",\"skin\":");

--- a/gltf/write.cpp
+++ b/gltf/write.cpp
@@ -1185,7 +1185,8 @@ void writeMeshNode(std::string& json, size_t mesh_offset, std::string& name, cgl
 	comma(json);
 	append(json, "{\"mesh\":");
 	append(json, mesh_offset);
-	if (!name.empty()) {
+	if (!name.empty())
+	{
 		append(json, ",\"name\":\"");
 		append(json, name);
 		append(json, "\"");


### PR DESCRIPTION
[BIM-272 | Packed metadata from gltfpack](https://fieldwire.atlassian.net/browse/BIM-272)

This PR aims at generating an additional output file from the `gltfpack` utility to keep track of the meshes that are merged together. 

The aim is to optionally use this information on our mobile apps to show objects properties. Using `gltfpack` is very helpful as it reduces the draw count by merging meshes together, which makes complex models viewable on mobile. The caveat is that we lose the meshes _metadata_ information. 

# How it is done

There are several key pieces that follow the order of commits:
- at parsing time (in `parsegltf.cpp`), we first retrieve the parent node from meshes, as parent nodes carry out the name used to retrieve properties. But a parent node can have several mesh child nodes, so we also keep the index of the mesh from its parent node. Both pieces of information are stores into the main `Mesh` struct.
- at processing time (in `gltfpack.cpp`), we disable one optimization using a new option named `-kmpn` (for _keep mesh parent nodes_). This option makes sure the merged mesh's parent nodes are kept as they are the ones that carry out the names used to retrieve properties. At the end, we have the same number of parent nodes as merges meshes. Their names are generated dynamically, from the information retrieved at parsing time, and we write them into the merged mesh's parent nodes.
- the key step is the merging one (in `mesh.cpp`), where a _source_ mesh is merged into a _target_ mesh. At this step, we keep two pieces of information into the target mesh:
    - the parent node name of the source mesh
    - the `index_offset` where the triangle vertice positions of the source mesh are copied over into the target mesh
- finally, we print the metadata information into an output file, using a new option named `-mmi` (for _merge mesh information_). Here, we just iterate over the merged meshes, and format the useful information stored at the previous step.

----

To illustrate, let's take this GLTF file example:
```
 "meshes": [
    /* mesh with 12 indices */
    {
      "primitives": [
        ...
      ]
    },
    /* mesh with 36 indices that will be merged into the first one */
    {
      "primitives": [
        ...
      ]
    },
    /* mesh with 9 indices that will be merged into the first one */
    {
      "primitives": [
        ...
      ]
    },
  ],
  "nodes": [
    {
      "mesh": 0,
    },
    {
      "mesh": 1,
    },
    {
      "mesh": 2,
    },
    {
      "name": "0yiBM2NAH96xSSnOnrhhld",
      "children": [0, 1]
    },
    {
      "name": "3j913Y4av3qOaiLIYT4b6p",
      "children": [2]
    }
  ]
```

The output metadata file should contain:
```
{
  "0yiBM2NAH96xSSnOnrhhld_0": {   // note the _0 that indicates the first child mesh of 0yiBM2NAH96xSSnOnrhhld
    "0": "0yiBM2NAH96xSSnOnrhhld", // for the 2 first meshes (12+36=48 indices)
    "48": "3j913Y4av3qOaiLIYT4b6p"  //  3rd mesh
}
```

On the client side, when the merged mesh `0yiBM2NAH96xSSnOnrhhld_0` is touched, we'll need to retrieve the triangle that was selected in the mesh. From the triangle, we can retrieve its vertices, then its corresponding indices. If we find indices 51, 52, 53 for example, we know that it's after 48, so that's the initial 3rd mesh that was selected. We get `3j913Y4av3qOaiLIYT4b6p` and can display the corresponding property 🙌. 

# How to read

Read by commit

# How to test

- To build, follow instructions at the end of [this page](https://github.com/zeux/meshoptimizer/tree/master/gltf).
- Take an input `glb` file and run this command line:
```
./gltfpack -i input.glb -o packed.glb -vp 16 -vn 16 -vc 16 -vpf -cc -v -kmpn -mmi metadata.json
```
- See the produced `output.json` file 