### PR TITLE
Fix corner case when the mesh parent node does not exist

### DIFF
--- a/gltf/gltfpack.cpp
+++ b/gltf/gltfpack.cpp
@@ -77,7 +77,7 @@ static void finalizeBufferViews(std::string& json, std::vector<BufferView>& view
 
 static void mesh_name_with_parent_node_info(const Mesh& mesh, std::string* mesh_name)
 {
-	 // compute a unique name for the mesh, since a parent node with a given name can have several meshes
+	// compute a unique name for the mesh, since a parent node with a given name can have several meshes
 	*mesh_name = std::string(mesh.parent_node_name) + "_" + std::to_string(mesh.index_in_parent_node);
 }
 
@@ -196,6 +196,9 @@ static bool printMergeMetadata(const char* path, const std::vector<Mesh>& meshes
 	for (size_t i = 0; i < meshes.size(); ++i)
 	{
 		const Mesh& mesh = meshes[i];
+		if (!mesh.parent_node_name) {
+			continue;
+		}
 		std::string mesh_unique_name = std::string();
 		mesh_name_with_parent_node_info(mesh, &mesh_unique_name);
 
@@ -630,7 +633,7 @@ static void process(cgltf_data* data, const char* input_path, const char* output
 		const Mesh& mesh = meshes[i];
 
 		std::string mesh_name = std::string();
-		if (settings.keep_mesh_parent_nodes)
+		if (settings.keep_mesh_parent_nodes && mesh.parent_node_name)
 		{
 			mesh_name_with_parent_node_info(mesh, &mesh_name);
 		}

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -260,7 +260,7 @@ static void mergeMeshes(Mesh& target, const Mesh& mesh, const Settings& settings
 	for (size_t i = 0; i < index_count; ++i)
 	{
 		target.indices[index_offset + i] = unsigned(vertex_offset + mesh.indices[i]);
-		if (settings.keep_mesh_parent_nodes)
+		if (settings.keep_mesh_parent_nodes && mesh.parent_node_name)
 		{
 			target.merged_meshes_parent_node_info.push_back(std::pair<const char*, unsigned int>(mesh.parent_node_name, index_offset));
 		}


### PR DESCRIPTION
[[BIM-325 | [Converter] Fix gltfpack issue on some models with unexpected gltf structure]](https://fieldwire.atlassian.net/browse/BIM-325)

This PR aims at fixing some corner cases where some generated gltf files have meshes with no parent nodes. In this case, the merged information is not added since information is missing. This is ok for the 3 models we have in this case that do not carry any metadata after the main conversion.