### PR TITLE
Skips optimizeMesh for merged meshes

### DIFF
--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -833,7 +833,9 @@ void processMesh(Mesh& mesh, const Settings& settings)
 		filterTriangles(mesh);
 		if (settings.simplify_ratio < 1)
 			simplifyMesh(mesh, settings.simplify_ratio, settings.simplify_error, settings.simplify_attributes, settings.simplify_aggressive, settings.simplify_lock_borders);
-		optimizeMesh(mesh, settings.compressmore);
+		// Skip optimizeMesh for merged meshes to preserve metadata offset mappings
+		if (mesh.merged_meshes_parent_node_info.empty())
+			optimizeMesh(mesh, settings.compressmore);
 		break;
 
 	default:

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -829,13 +829,15 @@ void processMesh(Mesh& mesh, const Settings& settings)
 
 	case cgltf_primitive_type_triangles:
 		filterBones(mesh);
-		reindexMesh(mesh);
-		filterTriangles(mesh);
-		if (settings.simplify_ratio < 1)
-			simplifyMesh(mesh, settings.simplify_ratio, settings.simplify_error, settings.simplify_attributes, settings.simplify_aggressive, settings.simplify_lock_borders);
-		// Skip optimizeMesh for merged meshes to preserve metadata offset mappings
+		// Skip index-reordering operations for merged meshes to preserve metadata offset mappings
 		if (mesh.merged_meshes_parent_node_info.empty())
+		{
+			reindexMesh(mesh);
+			filterTriangles(mesh);
+			if (settings.simplify_ratio < 1)
+				simplifyMesh(mesh, settings.simplify_ratio, settings.simplify_error, settings.simplify_attributes, settings.simplify_aggressive, settings.simplify_lock_borders);
 			optimizeMesh(mesh, settings.compressmore);
+		}
 		break;
 
 	default:


### PR DESCRIPTION
https://fieldwire.atlassian.net/browse/BIM-1009

## The Problem
When using gltfpack with the -kmpn flag to preserve mesh provenance information, the generated metadata became unreliable. The metadata tracks which original mesh each index segment came from critical for our BIM workflows where you need to know the original model data. But after packing, queries for index offsets would return the wrong parent node IDs.
## Root Cause
The issue was a timing problem. Here's what was happening:
1. During mesh merging, gltfpack recorded metadata offsets based on the current index positions
2. After recording those offsets, it applied vertex deduplication (reindexMesh()) which reordered indices
3. The recorded offsets no longer pointed to the correct segments i.e. they were off by however much the indices shifted

More debugging information documented [here](https://fieldwire.atlassian.net/wiki/spaces/~896862870/pages/3341221911/Debugging+GLTFpack+Metadata+Mismatch+Investigation)

## The Solution
Rather than try to track all the index remappings (which would be complex and error-prone), we simply skip the index-reordering operations for merged meshes. This keeps the index order intact so the pre-recorded offsets remain valid.
The trade-off: Files are slightly larger (2-3% for large models with many merged meshes) because vertices aren't deduplicated across merged segments. This is acceptable because:
- Non-merged meshes remain fully optimized
- The modest size increase is worth the accuracy guarantee
### What Changed
- Modified processMesh() in gltf/mesh.cpp to skip optimization operations when a mesh has merged metadata
### Testing
- Manual testing using testcases
- Visually test with various clients (iOS/web) to verify the correctness of the mappings
### Performance Impact
776.glb (Large BIM):    95.89 MB → 98.50 MB (+2.72%)
636.glb (Small):       0.48 MB → 0.49 MB (+0.34%)
The increase is proportional to the number of merged meshes.