### PR TITLE
- BIM-1304: Handle shared instance meshes

### DIFF
--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -65,6 +65,7 @@ struct Mesh
 
 	const char* parent_node_name;
 	size_t index_in_parent_node;
+	std::vector<const char*> node_parent_names;
 
 	std::vector<std::pair<const char*, unsigned int> >merged_meshes_parent_node_info;
 };

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -275,8 +275,11 @@ void mergeMeshInstances(Mesh& mesh, const Settings& settings)
 	// fast-path: for single instance meshes we transform in-place
 	if (mesh.nodes.size() == 1)
 	{
+		if (settings.keep_mesh_parent_nodes && !mesh.node_parent_names.empty() && mesh.node_parent_names[0])
+			mesh.parent_node_name = mesh.node_parent_names[0];
 		transformMesh(mesh, mesh, mesh.nodes[0]);
 		mesh.nodes.clear();
+		mesh.node_parent_names.clear();
 		return;
 	}
 
@@ -294,11 +297,17 @@ void mergeMeshInstances(Mesh& mesh, const Settings& settings)
 
 	for (size_t i = 0; i < mesh.nodes.size(); ++i)
 	{
+		// set the correct parent_node_name for this instance so mergeMeshes
+		// records the right parent in merged_meshes_parent_node_info
+		if (settings.keep_mesh_parent_nodes && i < mesh.node_parent_names.size() && mesh.node_parent_names[i])
+			transformed.parent_node_name = mesh.node_parent_names[i];
+
 		transformMesh(transformed, base, mesh.nodes[i]);
 		mergeMeshes(mesh, transformed, settings);
 	}
 
 	mesh.nodes.clear();
+	mesh.node_parent_names.clear();
 }
 
 void mergeMeshes(std::vector<Mesh>& meshes, const Settings& settings)

--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -148,7 +148,7 @@ static bool isIdAttribute(const char* name)
 	       strncmp(name, "_FEATURE_ID_", 12) == 0;
 }
 
-static void createNodesToChildMeshesMap(cgltf_data* data, std::map<cgltf_mesh*, std::pair<const char*, const size_t> >& map)
+static void createNodesToChildMeshesMap(cgltf_data* data, std::map<cgltf_mesh*, std::pair<const char*, const size_t> >& map, std::map<cgltf_node*, const char*>& node_parent_map)
 {
 	for (size_t ni = 0; ni < data->nodes_count; ++ni)
 	{
@@ -161,6 +161,7 @@ static void createNodesToChildMeshesMap(cgltf_data* data, std::map<cgltf_mesh*, 
 			if (child_node->mesh && node.name)
 			{
 				map.insert(std::pair<cgltf_mesh*, std::pair<const char*, const size_t> >(child_node->mesh, std::make_pair(node.name, j)));
+				node_parent_map[child_node] = node.name;
 			}
 		}
 	}
@@ -351,7 +352,7 @@ static void parseMeshInstancesGltf(std::vector<Transform>& instances, cgltf_node
 	}
 }
 
-static void parseMeshNodesGltf(cgltf_data* data, std::vector<Mesh>& meshes, const std::vector<std::pair<size_t, size_t> >& mesh_remap)
+static void parseMeshNodesGltf(cgltf_data* data, std::vector<Mesh>& meshes, const std::vector<std::pair<size_t, size_t> >& mesh_remap, const std::map<cgltf_node*, const char*>& node_parent_map)
 {
 	for (size_t i = 0; i < data->nodes_count; ++i)
 	{
@@ -383,6 +384,10 @@ static void parseMeshNodesGltf(cgltf_data* data, std::vector<Mesh>& meshes, cons
 			{
 				mesh->skin = node.skin;
 				mesh->nodes.push_back(&node);
+
+				// track the parent name for this specific node
+				std::map<cgltf_node*, const char*>::const_iterator it = node_parent_map.find(&node);
+				mesh->node_parent_names.push_back(it != node_parent_map.end() ? it->second : NULL);
 			}
 		}
 	}
@@ -631,9 +636,10 @@ static cgltf_data* parseGltf(cgltf_data* data, cgltf_result result, std::vector<
 	std::vector<std::pair<size_t, size_t> > mesh_remap;
 	std::map<cgltf_mesh*, std::pair<const char*, const size_t> > nodes_to_child_meshes_map;
 
-	createNodesToChildMeshesMap(data, nodes_to_child_meshes_map);
+	std::map<cgltf_node*, const char*> node_parent_map;
+	createNodesToChildMeshesMap(data, nodes_to_child_meshes_map, node_parent_map);
 	parseMeshesGltf(data, meshes, mesh_remap, nodes_to_child_meshes_map);
-	parseMeshNodesGltf(data, meshes, mesh_remap);
+	parseMeshNodesGltf(data, meshes, mesh_remap, node_parent_map);
 	parseAnimationsGltf(data, animations);
 
 	bool free_bin = freeUnusedBuffers(data);


### PR DESCRIPTION
This PR adds support for shared instanced meshes by tracking the parent name of each child node.

Instanced meshes that are shared between two different parents will have each of the distinct parents referenced in the metadata.

See: https://fieldwire.atlassian.net/browse/BIM-1304 for more info