### PR TITLE
Target meshes now consume the merge history of the consumed mesh

### DIFF
--- a/gltf/gltfpack.h
+++ b/gltf/gltfpack.h
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <vector>
+#include <map>
 
 struct Attr
 {
@@ -65,7 +66,7 @@ struct Mesh
 
 	const char* parent_node_name;
 	size_t index_in_parent_node;
-	std::vector<const char*> node_parent_names;
+	std::map<cgltf_node*, const char*> node_parent_names;
 
 	std::vector<std::pair<const char*, unsigned int> >merged_meshes_parent_node_info;
 };

--- a/gltf/mesh.cpp
+++ b/gltf/mesh.cpp
@@ -260,9 +260,18 @@ static void mergeMeshes(Mesh& target, const Mesh& mesh, const Settings& settings
 	for (size_t i = 0; i < index_count; ++i)
 	{
 		target.indices[index_offset + i] = unsigned(vertex_offset + mesh.indices[i]);
-		if (settings.keep_mesh_parent_nodes && mesh.parent_node_name)
-		{
-			target.merged_meshes_parent_node_info.push_back(std::pair<const char*, unsigned int>(mesh.parent_node_name, index_offset));
+	}
+
+	if (settings.keep_mesh_parent_nodes && mesh.parent_node_name)
+	{
+		target.merged_meshes_parent_node_info.push_back(std::pair<const char*, unsigned int>(mesh.parent_node_name, index_offset));
+
+		// When the target mesh consumes another mesh, it must also inherit that mesh's existing parent-node mappings.
+		// This is required for -mm instance merging. Without -mm, meshes are merged strictly left-to-right, guaranteeing that
+		// a consumed mesh has never previously consumed another mesh. Instance merging occurs before the standard merge pass,
+		// making it possible to consume a mesh that already contains mappings inherited from earlier merges.
+		for (const auto& pair : mesh.merged_meshes_parent_node_info) {
+			target.merged_meshes_parent_node_info.push_back({ pair.first, pair.second + index_offset });
 		}
 	}
 }
@@ -275,8 +284,8 @@ void mergeMeshInstances(Mesh& mesh, const Settings& settings)
 	// fast-path: for single instance meshes we transform in-place
 	if (mesh.nodes.size() == 1)
 	{
-		if (settings.keep_mesh_parent_nodes && !mesh.node_parent_names.empty() && mesh.node_parent_names[0])
-			mesh.parent_node_name = mesh.node_parent_names[0];
+		if (settings.keep_mesh_parent_nodes && mesh.node_parent_names.find(mesh.nodes[0]) != mesh.node_parent_names.end())
+			mesh.parent_node_name = mesh.node_parent_names[mesh.nodes[0]];
 		transformMesh(mesh, mesh, mesh.nodes[0]);
 		mesh.nodes.clear();
 		mesh.node_parent_names.clear();
@@ -299,8 +308,8 @@ void mergeMeshInstances(Mesh& mesh, const Settings& settings)
 	{
 		// set the correct parent_node_name for this instance so mergeMeshes
 		// records the right parent in merged_meshes_parent_node_info
-		if (settings.keep_mesh_parent_nodes && i < mesh.node_parent_names.size() && mesh.node_parent_names[i])
-			transformed.parent_node_name = mesh.node_parent_names[i];
+		if (settings.keep_mesh_parent_nodes && mesh.node_parent_names.find(mesh.nodes[i]) != mesh.node_parent_names.end())
+			transformed.parent_node_name = mesh.node_parent_names[mesh.nodes[i]];
 
 		transformMesh(transformed, base, mesh.nodes[i]);
 		mergeMeshes(mesh, transformed, settings);

--- a/gltf/parsegltf.cpp
+++ b/gltf/parsegltf.cpp
@@ -385,9 +385,12 @@ static void parseMeshNodesGltf(cgltf_data* data, std::vector<Mesh>& meshes, cons
 				mesh->skin = node.skin;
 				mesh->nodes.push_back(&node);
 
-				// track the parent name for this specific node
+				// A mesh can be referenced by multiple nodes (instancing), so we store a mapping of child nodes to their parent node names
+				// This is used during instance merging, when only the child node is available and it has neither a name nor a reference to its parent
 				std::map<cgltf_node*, const char*>::const_iterator it = node_parent_map.find(&node);
-				mesh->node_parent_names.push_back(it != node_parent_map.end() ? it->second : NULL);
+				if (it != node_parent_map.end()) {
+					mesh->node_parent_names[&node] = it->second;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR address the issue of a target mesh not consuming the merge history of the consumed mesh.

This problem was identified when we introduced the `-mm` flag, which enforces the merging of instanced meshes. 

Prior to this a target mesh was always guaranteed to consume an un-merged mesh due to the "Left -> Right" merging algorithm. However, instance merging takes place prior to the standard mesh merge process. This introduces a scenario where the "Left -> Right" merging algorithm can no longer guarantee the consuming of a non-merged mesh. We now enforce the target to consume the merge history of the consumed mesh. 

I also swapped out the mesh parent node names mapping from a vector to a map. This change was a side effect of my debugging process to eliminate possible indexing errors, it turned out not to be an issue, but I decided to keep it because it guarantees we select the proper parent node name regardless of indexing and lets me sleep better at night. 